### PR TITLE
Fix container exit on process failure

### DIFF
--- a/mqtt-io/rootfs/etc/services.d/mqtt-io/finish
+++ b/mqtt-io/rootfs/etc/services.d/mqtt-io/finish
@@ -3,7 +3,7 @@
 # Home Assistant Community Add-on: MQTT IO
 # Take down the S6 supervision tree when MQTT IO fails
 # ==============================================================================
-if -n { s6-test $# -ne 0 }
-if -n { s6-test ${1} -eq 256 }
+if { s6-test ${1} -ne 0 }
+if { s6-test ${1} -ne 256 }
 
 s6-svscanctl -t /var/run/s6/services


### PR DESCRIPTION
# Proposed Changes

Fix container exit on process failure, from tests I did the `s6-test ${1}` returns 1 when the process fails with errors. I am not sure if the `not equal 256` is needed, but noticed 30 addons which check for `not equal 0` has the same check.

## Related Issues

https://github.com/hassio-addons/addon-mqtt-io/pull/1

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
