### PR TITLE
Fix container build failure

### DIFF
--- a/mqtt-io/Dockerfile
+++ b/mqtt-io/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:11.0.1
+ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:11.1.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -15,7 +15,6 @@ RUN \
     apk add --no-cache --virtual .build-dependencies \
         build-base=0.5-r2 \
         libffi-dev=3.4.2-r1 \
-        openssl-dev=1.1.1l-r8 \
         py3-wheel=0.36.2-r2 \
         python3-dev=3.9.7-r4 \
     \

--- a/mqtt-io/build.yaml
+++ b/mqtt-io/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base/aarch64:11.0.1
-  amd64: ghcr.io/hassio-addons/base/amd64:11.0.1
-  armhf: ghcr.io/hassio-addons/base/armhf:11.0.1
-  armv7: ghcr.io/hassio-addons/base/armv7:11.0.1
-  i386: ghcr.io/hassio-addons/base/i386:11.0.1
+  aarch64: ghcr.io/hassio-addons/base/aarch64:11.1.0
+  amd64: ghcr.io/hassio-addons/base/amd64:11.1.0
+  armhf: ghcr.io/hassio-addons/base/armhf:11.1.0
+  armv7: ghcr.io/hassio-addons/base/armv7:11.1.0
+  i386: ghcr.io/hassio-addons/base/i386:11.1.0


### PR DESCRIPTION
# Proposed Changes
Fix container build failure
- Remove `openssl-dev` from build dependencies, seems like it is not needed since build pass successfully without it
- Update addon base image to `11.1.0` 
## Related Issues

https://github.com/hassio-addons/addon-mqtt-io/runs/6052596633?check_suite_focus=true

```
#8 1.807   libssl1.1-1.1.1l-r8:
#8 1.807     breaks: openssl-dev-1.1.1n-r0[libssl1.1=1.1.1n-r0]
#8 1.807     satisfies: world[libssl1.1=1.1.1l-r8]
#8 1.807                python3-3.9.7-r4[so:libssl.so.1.1]
#8 1.807                libretls-3.3.4-r2[so:libssl.so.1.1]
#8 1.807                libcurl-7.80.0-r0[so:libssl.so.1.1]
#8 1.807                apk-tools-2.12.7-r3[so:libssl.so.1.1]
#8 1.807   openssl-dev-1.1.1n-r0:
#8 1.807     breaks: .build-dependencies-20220417.074138[openssl-dev=1.1.1l-r8]
```
[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
