### PR TITLE
Fix addon stop message

### DIFF
--- a/mqtt-io/rootfs/etc/services.d/mqtt-io/finish
+++ b/mqtt-io/rootfs/etc/services.d/mqtt-io/finish
@@ -8,4 +8,4 @@ if [[ "${1}" -ne 0 ]] && [[ "${1}" -ne 256 ]]; then
   exec /run/s6/basedir/bin/halt
 fi
 
-bashio::log.info "MQTT IO  stopped, restarting..."
+bashio::log.info "MQTT IO  stopped"

--- a/mqtt-io/rootfs/etc/services.d/mqtt-io/finish
+++ b/mqtt-io/rootfs/etc/services.d/mqtt-io/finish
@@ -8,4 +8,4 @@ if [[ "${1}" -ne 0 ]] && [[ "${1}" -ne 256 ]]; then
   exec /run/s6/basedir/bin/halt
 fi
 
-bashio::log.info "MQTT IO  stopped"
+bashio::log.info "MQTT IO stopped"


### PR DESCRIPTION
# Proposed Changes

Fix addon stop message, remove `, restarting...` since if watchdog is not enabled it will not trigger restart.
