### PR TITLE
Fix gpio permission

### DIFF
--- a/mqtt-io/config.yaml
+++ b/mqtt-io/config.yaml
@@ -19,7 +19,7 @@ privileged:
   - SYS_RAWIO
 devices:
   - /dev/mem
-  - /dev/gpiomem  
+  - /dev/gpiomem
 map:
   - config:rw
   - share:rw

--- a/mqtt-io/config.yaml
+++ b/mqtt-io/config.yaml
@@ -19,6 +19,7 @@ privileged:
   - SYS_RAWIO
 devices:
   - /dev/mem
+  - /dev/gpiomem  
 map:
   - config:rw
   - share:rw


### PR DESCRIPTION
# Proposed Changes

Fix GPIO permissions on Raspberry IP, required for MQTT.io `raspberrypi` and `gpiozero` modules.
Not sure if the `/dev/mem` can be removed now.

Without access to `/dev/gpiomem` the following error is shown:

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/mqtt_io/__main__.py", line 107, in main
    mqtt_gpio.run()
  File "/usr/lib/python3.10/site-packages/mqtt_io/server.py", line 1228, in run
    self._init_digital_inputs()
  File "/usr/lib/python3.10/site-packages/mqtt_io/server.py", line 387, in _init_digital_inputs
    gpio_module.setup_pin_internal(PinDirection.INPUT, in_conf)
  File "/usr/lib/python3.10/site-packages/mqtt_io/modules/gpio/__init__.py", line 207, in setup_pin_internal
    return self.setup_pin(
  File "/usr/lib/python3.10/site-packages/mqtt_io/modules/gpio/raspberrypi.py", line 56, in setup_pin
    self.io.setup(pin, direction, pull_up_down=pullup, initial=initial_int)
RuntimeError: Mmap of GPIO registers failed
```

According to the low level C code the driver try `/dev/gpiomem` first and if it fails it trys `/dev/mem` and it is stated that for `/dev/mem` process should run with root permissions.
