### PR TITLE
Pre-install Adafruit DHT

### DIFF
--- a/mqtt-io/Dockerfile
+++ b/mqtt-io/Dockerfile
@@ -24,6 +24,7 @@ RUN \
         python3=3.10.4-r0 \
     \
     && pip install -r /tmp/requirements.txt \
+    && pip install Adafruit_DHT==1.4.0 --install-option="--force-pi" \
     \
     && find /usr \
         \( -type d -a -name test -o -name tests -o -name '__pycache__' \) \


### PR DESCRIPTION
# Proposed Changes

Pre-installs Adafruit DHT. It is installed separately to be able to force the Raspberry Pi option (otherwise it will fail to detect the device in CI at build time).

I could have set the build option on our normal requirements file, however, that disables the use of pre-build wheels and causes issues with another package.

fixes #15
