### PR TITLE
Force Adafruit_DHT to build for rpi2

### DIFF
--- a/mqtt-io/Dockerfile
+++ b/mqtt-io/Dockerfile
@@ -24,7 +24,7 @@ RUN \
         python3=3.10.4-r0 \
     \
     && pip install -r /tmp/requirements.txt \
-    && pip install Adafruit_DHT==1.4.0 --install-option="--force-pi" \
+    && pip install Adafruit_DHT==1.4.0 --install-option="--force-pi2" \
     \
     && find /usr \
         \( -type d -a -name test -o -name tests -o -name '__pycache__' \) \


### PR DESCRIPTION
# Proposed Changes

For the installation of Adafruit_DHT for the pi2.

This extension will support the Pi2, Pi3 & Pi4. The previous code only supported the Pi1, which is exactly kinda useless, since Home Assistant OS + add-on will not run on that 😬 

fixes #17