### PR TITLE
Set w1thermsensor requirement version to 2.0.0

### DIFF
--- a/mqtt-io/requirements.txt
+++ b/mqtt-io/requirements.txt
@@ -15,4 +15,4 @@ pyserial==3.5
 RPi.bme280==0.2.4
 RPi.GPIO==0.7.1
 smbus2==0.4.2
-w1thermsensor==1.3.0
+w1thermsensor==2.0.0


### PR DESCRIPTION
# Proposed Changes

Set w1thermsensor requirement version to 2.0.0

The MQTT IO ds18b module using this 1-wire lib requires at least version
2.0.0.

Currently, it crashes when using the ds18b module because of unsatisfied dependency. Bumping the version fixes this.

Note: I did not manage to use this module for now. I struggled to expose the `/sys/bus/w1` tree in the addon.