### PR TITLE
Enable full access to devices

### DIFF
--- a/mqtt-io/config.yaml
+++ b/mqtt-io/config.yaml
@@ -13,13 +13,9 @@ arch:
   - i386
 init: false
 homeassistant_api: true
-uart: true
-gpio: true
+full_access: true
 privileged:
   - SYS_RAWIO
-devices:
-  - /dev/mem
-  - /dev/gpiomem
 map:
   - config:rw
   - share:rw

--- a/mqtt-io/config.yaml
+++ b/mqtt-io/config.yaml
@@ -13,13 +13,14 @@ arch:
   - i386
 init: false
 homeassistant_api: true
-full_access: true
 privileged:
   - SYS_RAWIO
 map:
   - config:rw
   - share:rw
   - ssl
+devices:
+  - /dev
 options:
   configuration_file: /config/mqtt-io/config.yml
 schema:


### PR DESCRIPTION
# Proposed Changes

A possible solution for #35.
This will highly degrade the security rating for this add-on, but it will provide the max access to hardware an add-on can possibly get in the Home Assistant ecosystem.

## Related Issues

needs #37
closes #35

