### PR TITLE
Bump mqtt-io to a specific commit

### DIFF
--- a/mqtt-io/Dockerfile
+++ b/mqtt-io/Dockerfile
@@ -13,6 +13,7 @@ COPY requirements.txt /tmp/
 RUN \
     apk add --no-cache --virtual .build-dependencies \
         build-base=0.5-r3 \
+        git=2.38.5-r0 \
         libffi-dev=3.4.4-r2 \
         py3-wheel=0.40.0-r1 \
         python3-dev=3.11.6-r0 \

--- a/mqtt-io/requirements.txt
+++ b/mqtt-io/requirements.txt
@@ -5,7 +5,7 @@ Adafruit-MCP3008==1.0.2
 bme680==1.1.1
 gpiod==1.5.4
 gpiozero==1.6.2
-mqtt-io==2.2.8
+mqtt-io @ git+https://github.com/flyte/mqtt-io@2bb2f945ea47ed87f99ab4fc966d2dbbd47fc7c7
 nfcpy==1.0.4
 pcf8574==0.1.3
 pcf8575==0.3


### PR DESCRIPTION
# Proposed Changes

SSIA, bumped it to a specific commit to circumvent cython 3x issues in the current version and get the highly needed PyYAML bump.

As there hasn't been a release of MQTT-io, I don't see a better solution.

