### PR TITLE
⬇️ Downgrade paho-mqtt to <2

### DIFF
--- a/mqtt-io/requirements.txt
+++ b/mqtt-io/requirements.txt
@@ -6,6 +6,7 @@ bme680==1.1.1
 gpiod==2.1.3
 gpiozero==2.0.1
 mqtt-io @ git+https://github.com/flyte/mqtt-io@2bb2f945ea47ed87f99ab4fc966d2dbbd47fc7c7
+paho-mqtt<2
 nfcpy==1.0.4
 pcf8574==0.1.3
 pcf8575==0.3


### PR DESCRIPTION
fixes #120

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated `paho-mqtt` package to enhance MQTT communication capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->