### PR TITLE
Autodiscovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,6 @@ SOFTWARE.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/addon-mqtt-io.svg
 [commits]: https://github.com/hassio-addons/addon-mqtt-io/commits/main
 [contributors]: https://github.com/hassio-addons/addon-mqtt-io/graphs/contributors

--- a/mqtt-io/DOCS.md
+++ b/mqtt-io/DOCS.md
@@ -17,10 +17,12 @@ comparison to installing any other Home Assistant add-on.
 1. Click the "Install" button to install the add-on.
 1. Set the location of the MQTT IO configuration file in the add-on options.
    By default, this will be `/config/mqtt-io/config.yml`.
-1. Create the MQTT IO configuration file. For information about the format
-   and configuration option, please consult the MQTT IO documentation:
+1. Start the add-on to create a default MQTT IO configuration file. For
+   information about the format and configuration options, please consult the
+   MQTT IO documentation:
    <https://mqtt-io.app/2.2.6/#/config/scenarios>
-1. Start the "MQTT IO" add-on when the configuration is created.
+1. Adjust the generated configuration for the devices you want to use and
+   restart the add-on.
 1. Check the logs of the "MQTT IO" add-on to see if everything went well.
 
 ## Configuration
@@ -46,7 +48,10 @@ For more information about the MQTT IO configuration file format, see:
 
 <https://mqtt-io.app/2.2.7/#/config/scenarios> and <https://mqtt-io.app/2.2.7/#/config/ha_discovery>
 
-Please note that this configuration file is not created automatically.
+If this file does not exist when the add-on starts, a minimal configuration is
+created automatically. When no MQTT host is configured in this file, the
+add-on uses the MQTT service provided by the Home Assistant Supervisor. Set
+`mqtt.host` in the MQTT IO configuration to use a different MQTT broker.
 
 ### Option: `log_level`
 

--- a/mqtt-io/Dockerfile
+++ b/mqtt-io/Dockerfile
@@ -20,6 +20,7 @@ RUN \
         py3-pip=26.1.2-r0 \
         python3=3.14.5-r0 \
         python3-dev=3.14.5-r0 \
+        yq-go=4.53.3-r0 \
     \
     && pip install --break-system-packages -r /tmp/requirements.txt \
     \

--- a/mqtt-io/Dockerfile
+++ b/mqtt-io/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:15.0.9
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:21.0.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -12,21 +12,16 @@ COPY requirements.txt /tmp/
 # hadolint ignore=DL3003,DL3042
 RUN \
     apk add --no-cache --virtual .build-dependencies \
-        build-base=0.5-r3 \
-        git=2.43.7-r0 \
-        libffi-dev=3.4.4-r3 \
-        py3-wheel=0.42.0-r0 \
-        python3-dev=3.11.14-r0 \
+        git=2.54.0-r0 \
     \
     && apk add --no-cache \
-        py3-bcrypt=4.1.1-r0 \
-        py3-cryptography=41.0.7-r0 \
-        py3-pip=23.3.1-r0 \
-        python3=3.11.14-r0 \
+        build-base=0.5-r4 \
+        linux-headers=7.0.0-r1 \
+        py3-pip=26.1.2-r0 \
+        python3=3.14.5-r0 \
+        python3-dev=3.14.5-r0 \
     \
-    && pip install --upgrade pip==23.0.1 \
-    && pip install -r /tmp/requirements.txt \
-    && pip install Adafruit_DHT==1.4.0 --install-option="--force-pi2" \
+    && pip install --break-system-packages -r /tmp/requirements.txt \
     \
     && find /usr \
         \( -type d -a -name test -o -name tests -o -name '__pycache__' \) \

--- a/mqtt-io/build.yaml
+++ b/mqtt-io/build.yaml
@@ -1,8 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base:15.0.9
-  amd64: ghcr.io/hassio-addons/base:15.0.9
-  armv7: ghcr.io/hassio-addons/base:15.0.9
+  aarch64: ghcr.io/hassio-addons/base:21.0.0
+  amd64: ghcr.io/hassio-addons/base:21.0.0
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@frenck.dev

--- a/mqtt-io/config.yaml
+++ b/mqtt-io/config.yaml
@@ -9,8 +9,11 @@ arch:
   - aarch64
   - amd64
 init: false
+hassio_api: true
 homeassistant_api: true
 full_access: true
+services:
+  - mqtt:want
 privileged:
   - SYS_RAWIO
 map:

--- a/mqtt-io/config.yaml
+++ b/mqtt-io/config.yaml
@@ -8,7 +8,6 @@ codenotary: codenotary@frenck.dev
 arch:
   - aarch64
   - amd64
-  - armv7
 init: false
 homeassistant_api: true
 full_access: true

--- a/mqtt-io/requirements.txt
+++ b/mqtt-io/requirements.txt
@@ -1,12 +1,12 @@
-adafruit-circuitpython-ads1x15==2.4.4
+adafruit-circuitpython-ads1x15==3.0.5
 adafruit-circuitpython-ahtx0==1.0.30
+adafruit-circuitpython-dht==4.0.12
 adafruit-circuitpython-mcp230xx==2.6.2
 Adafruit-MCP3008==1.0.2
-bme680==1.1.1
-gpiod==2.4.2
+bme680==2.0.0
+gpiod==2.5.0
 gpiozero==2.0.1
-mqtt-io @ git+https://github.com/flyte/mqtt-io@2bb2f945ea47ed87f99ab4fc966d2dbbd47fc7c7
-paho-mqtt==1.6.1
+mqtt-io @ git+https://github.com/flyte/mqtt-io@c5d99b9f53b0e0cc68e49608e0457376122f6434
 nfcpy==1.0.4
 pcf8574==0.1.3
 pcf8575==0.3
@@ -16,5 +16,6 @@ pifacedigitalio==3.0.5
 pyserial==3.5
 RPi.bme280==0.2.4
 RPi.GPIO==0.7.1
+setuptools==81.0.0
 smbus2==0.6.1
 w1thermsensor==2.3.0

--- a/mqtt-io/rootfs/etc/s6-overlay/s6-rc.d/mqtt-io/run
+++ b/mqtt-io/rootfs/etc/s6-overlay/s6-rc.d/mqtt-io/run
@@ -5,23 +5,32 @@
 # Runs MQTT IO
 # ==============================================================================
 declare configuration_file
+declare mqtt_host
 
 configuration_file=$(bashio::config 'configuration_file')
 if ! bashio::fs.file_exists "${configuration_file}"; then
-    bashio::log.fatal
-    bashio::log.fatal "Seems like the configured configuration file does"
-    bashio::log.fatal "not exists:"
-    bashio::log.fatal
-    bashio::log.fatal "${configuration_file}"
-    bashio::log.fatal
-    bashio::log.fatal "Please check the add-on configuration, or create the"
-    bashio::log.fatal "configuration file. More information about the"
-    bashio::log.fatal "configuration file format see:"
-    bashio::log.fatal
-    bashio::log.fatal "https://mqtt-io.app"
-    bashio::log.fatal
-    bashio::exit.nok
+    mkdir -p "$(dirname "${configuration_file}")" \
+        || bashio::exit.nok "Could not create the configuration directory"
+    cat <<EOF > "${configuration_file}"
+mqtt:
+  topic_prefix: mqtt_io
+  ha_discovery:
+    enabled: true
+EOF
+    bashio::log.info "Created default configuration: ${configuration_file}"
+fi
+
+mqtt_host=$(yq '.mqtt.host // ""' "${configuration_file}") \
+    || bashio::exit.nok "Could not read the MQTT IO configuration"
+
+if bashio::var.is_empty "${mqtt_host}" \
+    && bashio::var.has_value "$(bashio::services 'mqtt')"; then
+    export MQTT_IO_HOST="$(bashio::services 'mqtt' 'host')"
+    export MQTT_IO_PORT="$(bashio::services 'mqtt' 'port')"
+    export MQTT_IO_USER="$(bashio::services 'mqtt' 'username')"
+    export MQTT_IO_PASSWORD="$(bashio::services 'mqtt' 'password')"
+    bashio::log.info "Using the MQTT service provided by the Supervisor"
 fi
 
 bashio::log.info "Starting MQTT IO..."
-exec python3 -m mqtt_io "$(bashio::config 'configuration_file')"
+exec python3 -m mqtt_io "${configuration_file}"


### PR DESCRIPTION
# Proposed Changes

Added MQTT Autodiscovery for Home Assistant

## Related Issues

https://github.com/hassio-addons/addon-mqtt-io/issues/134
https://github.com/hassio-addons/addon-mqtt-io/issues/142
https://github.com/hassio-addons/addon-mqtt-io/issues/115
https://github.com/hassio-addons/addon-mqtt-io/issues/110
https://github.com/hassio-addons/addon-mqtt-io/pull/173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically creates a starter MQTT IO configuration when the add-on starts.
  * Uses Home Assistant’s MQTT service automatically when no MQTT host is configured.
  * Enables Home Assistant API access and MQTT service integration.
  * Adds support for updated hardware platforms and sensor libraries.

* **Documentation**
  * Updated installation instructions to reflect automatic configuration creation and restart steps.
  * Clarified MQTT configuration and Supervisor integration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->